### PR TITLE
PR to override to string methods

### DIFF
--- a/src/main/java/com/emmanuel/datastructures/arrays/dynamicarray/DynamicArray.java
+++ b/src/main/java/com/emmanuel/datastructures/arrays/dynamicarray/DynamicArray.java
@@ -1,4 +1,6 @@
-package com.emmanuel.datastructures.arrays;
+package com.emmanuel.datastructures.arrays.dynamicarray;
+
+import com.emmanuel.datastructures.arrays.staticarray.StaticArray;
 
 public class DynamicArray<T> extends StaticArray<T> implements DynamicArrayInterface<T> {
 
@@ -119,6 +121,19 @@ public class DynamicArray<T> extends StaticArray<T> implements DynamicArrayInter
     @Override
     public int size() {
         return currentSize;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("[");
+        for (int i = 0; ; i++) {
+            builder.append(get(i));
+            if (currentSize - 1 == i) {
+                return builder.append("]").toString();
+            }
+            builder.append(", ");
+        }
     }
 
     private boolean isValidIndex(int index) {

--- a/src/main/java/com/emmanuel/datastructures/arrays/dynamicarray/DynamicArrayInterface.java
+++ b/src/main/java/com/emmanuel/datastructures/arrays/dynamicarray/DynamicArrayInterface.java
@@ -1,4 +1,6 @@
-package com.emmanuel.datastructures.arrays;
+package com.emmanuel.datastructures.arrays.dynamicarray;
+
+import com.emmanuel.datastructures.arrays.ArrayInterface;
 
 public interface DynamicArrayInterface<T> extends ArrayInterface<T> {
     /**

--- a/src/main/java/com/emmanuel/datastructures/arrays/staticarray/StaticArray.java
+++ b/src/main/java/com/emmanuel/datastructures/arrays/staticarray/StaticArray.java
@@ -1,4 +1,7 @@
-package com.emmanuel.datastructures.arrays;
+package com.emmanuel.datastructures.arrays.staticarray;
+
+
+import com.emmanuel.datastructures.arrays.ArrayInterface;
 
 
 @SuppressWarnings({"unchecked", "ManualArrayCopy"})
@@ -66,5 +69,18 @@ public class StaticArray<T> implements ArrayInterface<T> {
 
     public T[] getArray() {
         return array;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("[");
+        for (int i = 0; ; i++) {
+            builder.append(get(i));
+            if (i == size() - 1) {
+                return builder.append("]").toString();
+            }
+            builder.append(", ");
+        }
     }
 }

--- a/src/test/java/com/emmanuel/datastructures/arrays/dynamicarray/DynamicArrayTest.java
+++ b/src/test/java/com/emmanuel/datastructures/arrays/dynamicarray/DynamicArrayTest.java
@@ -1,4 +1,4 @@
-package com.emmanuel.datastructures.arrays;
+package com.emmanuel.datastructures.arrays.dynamicarray;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -105,5 +105,15 @@ public class DynamicArrayTest {
         DynamicArray<String> dynamicArray = new DynamicArray<>();
         dynamicArray.clear();
         assertEquals(0, dynamicArray.size());
+    }
+
+    @Test
+    void ensureDynamicIsPrinted() {
+        DynamicArray<String> dynamicArray = new DynamicArray<>();
+        dynamicArray.add("Hi");
+        dynamicArray.add("Ha");
+        dynamicArray.add("He");
+        dynamicArray.add("Ho");
+        assertNotEquals("", dynamicArray.toString());
     }
 }

--- a/src/test/java/com/emmanuel/datastructures/arrays/staticarray/StaticArrayTest.java
+++ b/src/test/java/com/emmanuel/datastructures/arrays/staticarray/StaticArrayTest.java
@@ -1,4 +1,4 @@
-package com.emmanuel.datastructures.arrays;
+package com.emmanuel.datastructures.arrays.staticarray;
 
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This overrides the to string methods to the static and dynamic array classes so that it can print out the elements in each array. This also repackages both arrays into its own separate packages.

author(s): [Emmanuel]
closes: #10